### PR TITLE
Format fix for RTT

### DIFF
--- a/TimeSampleCorrelation/TimeSampleCorrelation/TimeCorrelation.cs
+++ b/TimeSampleCorrelation/TimeSampleCorrelation/TimeCorrelation.cs
@@ -128,11 +128,11 @@ namespace Microsoft.TimeCalibration.TimeSampleCorrelation
                     continue;
                 }
 
-                if (fields.Length >= 5)
+                /*if (fields.Length >= 5)
                 {
                     // Format 2
                     tscEnd = tscStart;
-                }
+                }*/
 
                 // Apply delta
                 tscStart -= delta;


### PR DESCRIPTION
Commented out code which returned zero for RTT.  This prevents NtpPing and the NTPMonitorService and charting from representing RTT.